### PR TITLE
适配RT Thread 5.0

### DIFF
--- a/examples/tinyusb_console_be.c
+++ b/examples/tinyusb_console_be.c
@@ -8,7 +8,7 @@
 #include <agile_console.h>
 #include <tusb.h>
 
-ALIGN(RT_ALIGN_SIZE)
+AGILE_CONSOLE_MEM_ALIGN
 static struct rt_semaphore _sem;
 static struct rt_timer _timer;
 static struct rt_ringbuffer _rb;
@@ -83,7 +83,7 @@ static void con_usb_output_entry(void *parameter)
     while (1) {
         do {
             level = rt_hw_interrupt_disable();
-            send_len = rt_ringbuffer_peak(&_rb, &send_ptr);
+            send_len = rt_ringbuffer_peek(&_rb, &send_ptr);
             rt_hw_interrupt_enable(level);
 
             if (send_len > 0) {

--- a/inc/agile_console.h
+++ b/inc/agile_console.h
@@ -27,6 +27,20 @@ extern "C" {
  * @{
  */
 
+/** @addtogroup AGILE_CONSOLE_Exported_Macros
+ * @{
+ */
+#ifndef AGILE_CONSOLE_MEM_ALIGN
+#ifdef rt_align
+#define AGILE_CONSOLE_MEM_ALIGN          rt_align(RT_ALIGN_SIZE)
+#else
+#define AGILE_CONSOLE_MEM_ALIGN          ALIGN(RT_ALIGN_SIZE)
+#endif
+#endif
+/**
+ * @}
+ */
+
 /**
  * @brief   Agile Console 后端接口结构体
  */
@@ -59,6 +73,7 @@ void agile_console_wakeup(void);
 /**
  * @}
  */
+
 
 #ifdef __cplusplus
 }

--- a/src/agile_console.c
+++ b/src/agile_console.c
@@ -88,7 +88,7 @@
 /** @defgroup AGILE_CONSOLE_Private_Variables Agile Console Private Variables
  * @{
  */
-ALIGN(RT_ALIGN_SIZE)
+AGILE_CONSOLE_MEM_ALIGN
 static uint8_t _rx_rb_buf[PKG_AGILE_CONSOLE_RX_BUFFER_SIZE];       /**< Agile Console 接收 ringbuffer 缓冲区 */
 static rt_slist_t _slist_head = RT_SLIST_OBJECT_INIT(_slist_head); /**< Agile Console 后端链表头节点 */
 static struct agile_console _console_dev = {0};                    /**< Agile Console 设备 */


### PR DESCRIPTION
1.  RT-Thread5.0修改了宏定义
https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/programming-manual/basic/basic?id=%e5%b8%b8%e8%a7%81%e5%ae%8f%e5%ae%9a%e4%b9%89%e8%af%b4%e6%98%8e

2. RT-Thread5.0修改了ringbuffer的函数名
https://github.com/RT-Thread/rt-thread/pull/6075